### PR TITLE
Fix link in ‘Enforce typed equality comparison’ pattern

### DIFF
--- a/patterns-base/src/main/resources/docs/description/Custom_Scala_TypedEquality.md
+++ b/patterns-base/src/main/resources/docs/description/Custom_Scala_TypedEquality.md
@@ -1,4 +1,4 @@
 Using the `==` and `!=` operators are not type-checked by the compiler.
 As an alternative, you should use type-checked `===` and `=!=` as provided by scalaz or cats.
 
-[Read more](https://hseeberger.github.io/blog/2013/05/30/implicits-unchained-type-safe-equality-part1/)
+[Read more](https://hseeberger.wordpress.com/2013/05/30/implicits-unchained-type-safe-equality-part-1/)


### PR DESCRIPTION
The details ‘Read More’ link in the ScalaMeta Pro ‘Enforce typed equality comparison’ pattern has been updated to a new URL.