### PR TITLE
Update SBT and Scala version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ project/plugins/project/
 project/project/
 /lib/
 lib/
+
+.metals
+.bloop

--- a/core/project/build.properties
+++ b/core/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.0
+sbt.version=1.2.8

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val scalaV = "2.12.6"
+  val scalaV = "2.12.8"
 
   val betterFiles   = "com.github.pathikrit" %% "better-files" % "3.6.0"
   val codacyEngine  = "com.codacy" %% "codacy-engine-scala-seed" % "3.0.168"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.0
+sbt.version=1.2.8


### PR DESCRIPTION
This PR updates the SBT version to `1.2.8` and scala version to `2.12.8`. Also ignored some generated files from metals server and bloop.
