### PR TITLE
Fix unittests for Custom_Scala_TypeParameterName

### DIFF
--- a/patterns-base/src/main/resources/docs/tests/Custom_Scala_TypeParameterName.scala
+++ b/patterns-base/src/main/resources/docs/tests/Custom_Scala_TypeParameterName.scala
@@ -1,13 +1,13 @@
 //#Patterns: Custom_Scala_TypeParameterName
 package docs.tests
 
-//#Issue: {"severity": "Warn", "line": 9, "patternId": "Custom_Scala_TypeParameterName"}
-//#Issue: {"severity": "Warn", "line": 11, "patternId": "Custom_Scala_TypeParameterName"}
-//#Issue: {"severity": "Warn", "line": 18, "patternId": "Custom_Scala_TypeParameterName"}
-//#Issue: {"severity": "Warn", "line": 23, "patternId": "Custom_Scala_TypeParameterName"}
-
+//#Warn: Custom_Scala_TypeParameterName
+//#Warn: Custom_Scala_TypeParameterName
 case class Entry[TKey, TProperties](key: TKey, properties: TProperties)
 
+//#Warn: Custom_Scala_TypeParameterName
+//#Warn: Custom_Scala_TypeParameterName
+//#Warn: Custom_Scala_TypeParameterName
 trait HistoryBuilder[TKey, TEntity <: Option[TProperties], TProperties]
 
 class Response[A]
@@ -15,9 +15,13 @@ class Response[A]
 trait TResponse[T]
 
 trait a {
+  //#Warn: Custom_Scala_TypeParameterName
+  //#Warn: Custom_Scala_TypeParameterName
+  //#Warn: Custom_Scala_TypeParameterName
   def HistoryEncoder[TKey, TEntity <: Option[Int], TProperties]()
 }
 
 case class Cat[T, B](key: T, properties: B)
 
+//#Warn: Custom_Scala_TypeParameterName
 trait Dog[F, G <: Option[String], Milk]

--- a/patterns-base/src/main/scala/codacy/patterns/Custom_Scala_TypeParameterName.scala
+++ b/patterns-base/src/main/scala/codacy/patterns/Custom_Scala_TypeParameterName.scala
@@ -11,7 +11,7 @@ class Custom_Scala_TypeParameterName(conf:Custom_Scala_TypeParameterName.Configu
 
   override def apply(tree: Tree): Iterable[Result] = {
     tree.collect {
-      case t@tparam"..$mods $tparamname[..$tparams] >: $tpeopt1 <: $tpeopt2 <% ..$tpes1 : ..$tpes2" if isOffender(tparamname) =>
+      case t@tparam"..$_ $tparamname[..$_] >: $_ <: $_ <% ..$_ : ..$_" if isOffender(tparamname) =>
         Result(message(tparamname), tparamname)
     }
   }


### PR DESCRIPTION
This PR fixes the unittesting reported by `codacy-plugins-test` on `Custom_Scala_TypeParameterName` rule/pattern. I also fixed a minor code readability issue using scala wildcards.

## Reported error
```
   -> Found:
   (Custom_Scala_TypeParameterName,9,Warning)
   (Custom_Scala_TypeParameterName,9,Warning)
   (Custom_Scala_TypeParameterName,11,Warning)
   (Custom_Scala_TypeParameterName,11,Warning)
   (Custom_Scala_TypeParameterName,11,Warning)
   (Custom_Scala_TypeParameterName,18,Warning)
   (Custom_Scala_TypeParameterName,18,Warning)
   (Custom_Scala_TypeParameterName,18,Warning)
   (Custom_Scala_TypeParameterName,23,Warning)
  -> Expected:
   (Custom_Scala_TypeParameterName,9,Warning)
   (Custom_Scala_TypeParameterName,11,Warning)
   (Custom_Scala_TypeParameterName,18,Warning)
   (Custom_Scala_TypeParameterName,23,Warning)
  --------------------------------------
  -> Missing:
   
  -> Extra:
   (Custom_Scala_TypeParameterName,9,Warning)
   (Custom_Scala_TypeParameterName,11,Warning)
   (Custom_Scala_TypeParameterName,11,Warning)
   (Custom_Scala_TypeParameterName,18,Warning)
   (Custom_Scala_TypeParameterName,18,Warning)
```