### PR TITLE
feature: Add again Custom_Scala_GetCalls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ workflows:
                  docker:publishLocal"
             docker save --output docker-image.tar $CIRCLE_PROJECT_REPONAME:latest
           persist_to_workspace: true
-          cache_prefix: sbt-cache-14092020
+          cache_prefix: sbt-cache-15092020
           requires:
             - codacy/checkout_and_version
       - codacy_plugins_test/run:
@@ -40,7 +40,7 @@ workflows:
             branches:
               only: master
           context: CodacyAWS
-          cache_prefix: sbt-cache-14092020
+          cache_prefix: sbt-cache-15092020
           requires:
             - publish_docker_local
             - plugins_test

--- a/patterns-base/src/main/resources/docs/description/description.json
+++ b/patterns-base/src/main/resources/docs/description/description.json
@@ -42,6 +42,12 @@
     "timeToFix": 5
   },
   {
+    "patternId": "Custom_Scala_GetCalls",
+    "title": "Prohibit get on Option and Either",
+    "description": "Calling get should be avoided on Option and Either.",
+    "timeToFix": 5
+  },
+  {
     "patternId": "Custom_Scala_GetInMethodName",
     "title": "Prohibit prefixing getters with get",
     "description": "Active names should be given to methods.",

--- a/patterns-base/src/main/resources/docs/tests/Custom_Scala_GetCalls.scala
+++ b/patterns-base/src/main/resources/docs/tests/Custom_Scala_GetCalls.scala
@@ -1,0 +1,58 @@
+//#Patterns: Custom_Scala_GetCalls
+package docs.tests
+
+class Get {
+
+  val optional1: Option[Int] = Option(1)
+  val optional2 = Option(1)
+  val optional3 = None
+
+  //#Warn: Custom_Scala_GetCalls
+  optional1.get
+  //#Warn: Custom_Scala_GetCalls
+  optional2.get
+  //#Warn: Custom_Scala_GetCalls
+  optional3.get
+
+  optional1.getOrElse(2)
+  optional2.getOrElse(3)
+  optional3.getOrElse(4)
+
+  //#Warn: Custom_Scala_GetCalls
+  Option(1).get
+
+  //#Warn: Custom_Scala_GetCalls
+  Option.empty[String].map(identity).get
+
+  //#Warn: Custom_Scala_GetCalls
+  None.get
+
+  //#Warn: Custom_Scala_GetCalls
+  Some(322).get
+
+  Option(423423).map(_ + 342).getOrElse(432)
+
+  //#Warn: Custom_Scala_GetCalls
+  Right(34).left.map(identity).right.get
+
+  //#Warn: Custom_Scala_GetCalls
+  println(Option("hello").get)
+
+  aFunction(Option("hello").get(1, 2, 3), 1, 2, None.get())
+
+  //#Warn: Custom_Scala_GetCalls
+  aFunctionWithTypeParameter[T](Option("hello").get)
+
+  //previously false positives:
+  object Bla {
+    def get[T](int: Int = 0): T = ???
+    def get[T]: T = get[T](0)
+
+  }
+
+  Bla.get[Int](352)
+  Bla.get[String]
+
+  Option(1).get()
+
+}

--- a/patterns-base/src/main/resources/patterns.json
+++ b/patterns-base/src/main/resources/patterns.json
@@ -64,7 +64,7 @@
       "patternId": "Custom_Scala_GetCalls",
       "category": "ErrorProne",
       "level": "Warning",
-      "enabled": true
+      "enabled": false
     },
     {
       "patternId": "Custom_Scala_GetInMethodName",

--- a/patterns-base/src/main/resources/patterns.json
+++ b/patterns-base/src/main/resources/patterns.json
@@ -61,6 +61,12 @@
       "enabled": true
     },
     {
+      "patternId": "Custom_Scala_GetCalls",
+      "category": "ErrorProne",
+      "level": "Warning",
+      "enabled": true
+    },
+    {
       "patternId": "Custom_Scala_GetInMethodName",
       "category": "ErrorProne",
       "level": "Info",

--- a/patterns-base/src/main/scala/codacy/patterns/Custom_Scala_GetCalls.scala
+++ b/patterns-base/src/main/scala/codacy/patterns/Custom_Scala_GetCalls.scala
@@ -1,0 +1,24 @@
+package codacy.patterns
+
+import codacy.base.Pattern
+
+import scala.meta._
+
+case object Custom_Scala_GetCalls extends Pattern {
+
+  override def apply(tree: Tree) = {
+
+    tree.collect {
+      case t @ Term.Select(a, Term.Name("get")) if isValid(t) =>
+        Result(message(t), t)
+    }
+  }
+
+  private[this] def message(tree: Tree) = Message("Usage of get on optional type.")
+
+  private[this] def isValid(t: Tree) = t.parent match {
+    case Some(_: Term.ApplyType) => false
+    case Some(Term.Apply((`t`, _))) => false
+    case _ => true
+  }
+}


### PR DESCRIPTION
- Fix false negative when the get is wrapped in a call
  Example: `println(None.get)`